### PR TITLE
Add custom ops in TOSA MLIR dialect

### DIFF
--- a/reference_model/CMakeLists.txt
+++ b/reference_model/CMakeLists.txt
@@ -24,6 +24,9 @@ if(BUILD_TOSA_REFERENCE_MODEL_EXECUTABLE)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/verify verify)
 endif()
 
+# Add custom TOSA operations
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/custom_tosa_ops custom_tosa_ops)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/reference_model/custom_tosa_ops/CMakeLists.txt
+++ b/reference_model/custom_tosa_ops/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required (VERSION 3.16)
+
+# Copyright (c) 2025, ARM Limited.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(MSVC)
+  add_compile_options("/Zc:preprocessor")
+endif()
+
+add_library(tosa_custom_ops_plugin SHARED
+    matrix_transform_op.cpp
+    attention_op.cpp
+)
+
+get_target_property(SERIALIZATION_INCLUDES tosa_serialization_lib INTERFACE_INCLUDE_DIRECTORIES)
+
+target_include_directories(tosa_custom_ops_plugin
+    PUBLIC
+        ${SERIALIZATION_INCLUDES}
+        "../include"
+        "../src"
+        "../src/ops"
+)
+
+target_link_libraries(tosa_custom_ops_plugin
+  PRIVATE
+    eigen
+    flatbuffers
+)

--- a/reference_model/custom_tosa_ops/attention_op.cpp
+++ b/reference_model/custom_tosa_ops/attention_op.cpp
@@ -1,0 +1,325 @@
+// Copyright (c) 2025, ARM Limited.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "custom_op_interface.h"
+#include "custom_registry.h"
+#include <json.hpp>
+#include <vector>
+#include <cmath>
+
+#ifdef _MSC_VER
+#define TOSA_EXPORT __declspec(dllexport)
+#else
+#define TOSA_EXPORT
+#endif
+
+using namespace tosa;
+using json = nlohmann::json;
+
+namespace TosaReference
+{
+
+/**
+ * @brief Custom Attention Operation
+ * 
+ * This operation implements various attention mechanisms used in transformer models.
+ * It supports scaled dot-product attention as used in the original transformer paper,
+ * as well as more efficient attention variants.
+ *
+ * Inputs:
+ * - query: Tensor of shape [batch_size, num_heads, seq_len_q, head_size]
+ * - key: Tensor of shape [batch_size, num_heads, seq_len_k, head_size]
+ * - value: Tensor of shape [batch_size, num_heads, seq_len_k, head_size]
+ * - mask (optional): Tensor of shape [batch_size, num_heads, seq_len_q, seq_len_k]
+ *
+ * Output:
+ * - attention_output: Tensor of shape [batch_size, num_heads, seq_len_q, head_size]
+ */
+class AttentionOp : public CustomOpInterface
+{
+public:
+    AttentionOp() = default;
+    AttentionOp(std::string& domain_name, std::string& operator_name, std::string& version)
+        : _domain_name(domain_name)
+        , _operator_name(operator_name)
+        , _version(version)
+    {}
+
+    int eval(std::vector<TosaReference::Tensor*>& input_tensors,
+             std::vector<TosaReference::Tensor*>& output_tensors,
+             const std::string& implementation_attrs) override
+    {
+        // Parse the implementation attributes as JSON
+        json attrs;
+        try {
+            attrs = json::parse(implementation_attrs);
+        } catch (const json::parse_error& e) {
+            std::cerr << "Error parsing implementation_attrs JSON: " << e.what() << std::endl;
+            return 1;
+        }
+
+        // Get the attention type from attributes
+        std::string attention_type = attrs.value("attention_type", "scaled_dot_product");
+        float scale = attrs.value("scale", 0.0f); // Scale factor for attention scores
+
+        // Validate input tensors
+        if (input_tensors.size() < 3 || output_tensors.empty()) {
+            std::cerr << "Attention requires at least 3 input tensors (Q, K, V) and 1 output tensor" << std::endl;
+            return 1;
+        }
+
+        // Get query, key, value tensors
+        auto query_tensor = input_tensors[0];
+        auto key_tensor = input_tensors[1];
+        auto value_tensor = input_tensors[2];
+        auto output_tensor = output_tensors[0];
+
+        // Get mask tensor if provided
+        TosaReference::Tensor* mask_tensor = nullptr;
+        if (input_tensors.size() > 3) {
+            mask_tensor = input_tensors[3];
+        }
+
+        // Only float types supported for now
+        if (query_tensor->getDType() != DType::FLOAT32 ||
+            key_tensor->getDType() != DType::FLOAT32 ||
+            value_tensor->getDType() != DType::FLOAT32) {
+            std::cerr << "Attention currently only supports FLOAT32 tensors" << std::endl;
+            return 1;
+        }
+
+        // Basic validation of tensor shapes
+        auto query_shape = query_tensor->getShape();
+        auto key_shape = key_tensor->getShape();
+        auto value_shape = value_tensor->getShape();
+        auto output_shape = output_tensor->getShape();
+
+        // Ensure tensors have rank 4
+        if (query_shape.size() != 4 || key_shape.size() != 4 || 
+            value_shape.size() != 4 || output_shape.size() != 4) {
+            std::cerr << "Attention requires tensors with rank 4" << std::endl;
+            return 1;
+        }
+
+        // Ensure batch_size and num_heads dimensions match
+        if (query_shape[0] != key_shape[0] || query_shape[0] != value_shape[0] ||
+            query_shape[1] != key_shape[1] || query_shape[1] != value_shape[1]) {
+            std::cerr << "Batch size and number of heads must match for Q, K, V tensors" << std::endl;
+            return 1;
+        }
+
+        // Ensure key and value sequence length match
+        if (key_shape[2] != value_shape[2]) {
+            std::cerr << "Key and value sequence lengths must match" << std::endl;
+            return 1;
+        }
+
+        // Ensure head dimensions match
+        if (query_shape[3] != key_shape[3]) {
+            std::cerr << "Query and key head dimensions must match" << std::endl;
+            return 1;
+        }
+
+        // Ensure output shape matches expected dimensions
+        if (output_shape[0] != query_shape[0] || output_shape[1] != query_shape[1] ||
+            output_shape[2] != query_shape[2] || output_shape[3] != value_shape[3]) {
+            std::cerr << "Output tensor shape does not match expected dimensions" << std::endl;
+            return 1;
+        }
+
+        // Get dimensions
+        int batch_size = query_shape[0];
+        int num_heads = query_shape[1];
+        int seq_len_q = query_shape[2];
+        int seq_len_k = key_shape[2];
+        int head_size = query_shape[3];
+
+        // Calculate scale factor if not provided
+        if (scale <= 0.0f) {
+            scale = 1.0f / std::sqrt(static_cast<float>(head_size));
+        }
+
+        // For each attention type, delegate to the appropriate function
+        if (attention_type == "scaled_dot_product") {
+            return evaluateScaledDotProductAttention(query_tensor, key_tensor, value_tensor, 
+                                                      mask_tensor, output_tensor, scale);
+        } else {
+            std::cerr << "Unknown attention type: " << attention_type << std::endl;
+            return 1;
+        }
+    }
+
+    std::string getDomainName() const override
+    {
+        return this->_domain_name;
+    }
+
+    std::string getOperatorName() const override
+    {
+        return this->_operator_name;
+    }
+
+    std::string getVersion() const override
+    {
+        return this->_version;
+    }
+
+    ~AttentionOp(){}
+
+private:
+    int evaluateScaledDotProductAttention(TosaReference::Tensor* query_tensor,
+                                          TosaReference::Tensor* key_tensor,
+                                          TosaReference::Tensor* value_tensor,
+                                          TosaReference::Tensor* mask_tensor,
+                                          TosaReference::Tensor* output_tensor,
+                                          float scale)
+    {
+        // Get dimensions from tensors
+        auto query_shape = query_tensor->getShape();
+        auto key_shape = key_tensor->getShape();
+        auto value_shape = value_tensor->getShape();
+        
+        int batch_size = query_shape[0];
+        int num_heads = query_shape[1];
+        int seq_len_q = query_shape[2];
+        int seq_len_k = key_shape[2];
+        int head_size = query_shape[3];
+
+        // Cast tensors to Eigen tensors of rank 4 (batch, heads, seq_len, head_size)
+        auto eigenQueryTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 4>>*>(query_tensor);
+        auto eigenKeyTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 4>>*>(key_tensor);
+        auto eigenValueTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 4>>*>(value_tensor);
+        auto eigenOutputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 4>>*>(output_tensor);
+
+        // Get references to tensors
+        auto& query = eigenQueryTensor->getTensor();
+        auto& key = eigenKeyTensor->getTensor();
+        auto& value = eigenValueTensor->getTensor();
+        auto& output = eigenOutputTensor->getTensor();
+
+        // Implementation of scaled dot-product attention
+        // For each batch and head:
+        // 1. Compute attention scores: Q * K^T
+        // 2. Scale attention scores
+        // 3. Apply mask (if provided)
+        // 4. Apply softmax
+        // 5. Compute weighted sum with values: softmax(QK^T) * V
+
+        // Process each batch and head individually
+        for (int b = 0; b < batch_size; b++) {
+            for (int h = 0; h < num_heads; h++) {
+                // 1. Compute attention scores: Q * K^T (seq_len_q x seq_len_k)
+                Eigen::Tensor<float, 2> attention_scores(seq_len_q, seq_len_k);
+                
+                // Manual matrix multiplication Q * K^T
+                for (int i = 0; i < seq_len_q; i++) {
+                    for (int j = 0; j < seq_len_k; j++) {
+                        float score = 0.0f;
+                        for (int k = 0; k < head_size; k++) {
+                            score += query(b, h, i, k) * key(b, h, j, k);
+                        }
+                        attention_scores(i, j) = score;
+                    }
+                }
+                
+                // 2. Scale attention scores
+                attention_scores = attention_scores * scale;
+                
+                // 3. Apply mask if provided
+                if (mask_tensor != nullptr) {
+                    auto eigenMaskTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 4>>*>(mask_tensor);
+                    auto& mask = eigenMaskTensor->getTensor();
+                    
+                    // Apply mask - set masked positions to large negative value
+                    for (int i = 0; i < seq_len_q; i++) {
+                        for (int j = 0; j < seq_len_k; j++) {
+                            if (mask(b, h, i, j) == 0.0f) { // 0 means masked position
+                                attention_scores(i, j) = -10000.0f; // Large negative value
+                            }
+                        }
+                    }
+                }
+                
+                // 4. Apply softmax
+                // First find the maximum value in each row for numerical stability
+                Eigen::Tensor<float, 1> row_max(seq_len_q);
+                for (int i = 0; i < seq_len_q; i++) {
+                    float max_val = -std::numeric_limits<float>::infinity();
+                    for (int j = 0; j < seq_len_k; j++) {
+                        max_val = std::max(max_val, attention_scores(i, j));
+                    }
+                    row_max(i) = max_val;
+                }
+                
+                // Compute softmax: exp(x - max) / sum(exp(x - max))
+                Eigen::Tensor<float, 2> softmax_scores(seq_len_q, seq_len_k);
+                Eigen::Tensor<float, 1> row_sum(seq_len_q);
+                row_sum.setZero();
+                
+                // Compute exp(x - max) and row sums
+                for (int i = 0; i < seq_len_q; i++) {
+                    for (int j = 0; j < seq_len_k; j++) {
+                        float exp_val = std::exp(attention_scores(i, j) - row_max(i));
+                        softmax_scores(i, j) = exp_val;
+                        row_sum(i) += exp_val;
+                    }
+                }
+                
+                // Normalize by row sums
+                for (int i = 0; i < seq_len_q; i++) {
+                    for (int j = 0; j < seq_len_k; j++) {
+                        softmax_scores(i, j) /= row_sum(i);
+                    }
+                }
+                
+                // 5. Compute weighted sum with values: softmax(QK^T) * V
+                // For each query position and head dimension
+                for (int i = 0; i < seq_len_q; i++) {
+                    for (int d = 0; d < value_shape[3]; d++) {
+                        float weighted_sum = 0.0f;
+                        for (int j = 0; j < seq_len_k; j++) {
+                            weighted_sum += softmax_scores(i, j) * value(b, h, j, d);
+                        }
+                        output(b, h, i, d) = weighted_sum;
+                    }
+                }
+            }
+        }
+        
+        return 0;
+    }
+
+    std::string _domain_name;
+    std::string _operator_name;
+    std::string _version;
+};
+
+CustomOpInterface* createAttentionOp()
+{
+    std::string domain_name = "TosaMlirCustom";
+    std::string operator_name = "Attention";
+    std::string version = "1.0";
+    CustomOpInterface* customOp_ptr = new AttentionOp(domain_name, operator_name, version);
+
+    return customOp_ptr;
+}
+
+extern "C" TOSA_EXPORT int getCustomOpCreationFuncs(registration_callback_t registration_func)
+{
+    std::string domain_name = "TosaMlirCustom";
+    std::string operator_name = "Attention";
+    return registration_func(domain_name, operator_name, &createAttentionOp);
+}
+
+} // namespace TosaReference

--- a/reference_model/custom_tosa_ops/matrix_transform_op.cpp
+++ b/reference_model/custom_tosa_ops/matrix_transform_op.cpp
@@ -1,0 +1,346 @@
+// Copyright (c) 2025, ARM Limited.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "custom_op_interface.h"
+#include "custom_registry.h"
+#include <json.hpp>
+#include <vector>
+
+#ifdef _MSC_VER
+#define TOSA_EXPORT __declspec(dllexport)
+#else
+#define TOSA_EXPORT
+#endif
+
+using namespace tosa;
+using json = nlohmann::json;
+
+namespace TosaReference
+{
+
+/**
+ * @brief Custom Matrix Transform Operation
+ * 
+ * This operation provides specialized matrix transformations for ML workloads.
+ * Supports operations like:
+ * - Reshape (specialized for matrices)
+ * - Transpose
+ * - Matrix packing for efficient computation
+ * - Special transformations for attention mechanisms
+ */
+class MatrixTransformOp : public CustomOpInterface
+{
+public:
+    MatrixTransformOp() = default;
+    MatrixTransformOp(std::string& domain_name, std::string& operator_name, std::string& version)
+        : _domain_name(domain_name)
+        , _operator_name(operator_name)
+        , _version(version)
+    {}
+
+    int eval(std::vector<TosaReference::Tensor*>& input_tensors,
+             std::vector<TosaReference::Tensor*>& output_tensors,
+             const std::string& implementation_attrs) override
+    {
+        // Parse the implementation attributes as JSON
+        json attrs;
+        try {
+            attrs = json::parse(implementation_attrs);
+        } catch (const json::parse_error& e) {
+            std::cerr << "Error parsing implementation_attrs JSON: " << e.what() << std::endl;
+            return 1;
+        }
+
+        // Get the transform type from attributes
+        std::string transform_type = attrs.value("transform_type", "transpose");
+
+        // Check if we have at least one input and output tensor
+        if (input_tensors.empty() || output_tensors.empty()) {
+            std::cerr << "Matrix transform requires at least one input and output tensor" << std::endl;
+            return 1;
+        }
+
+        auto input_tensor = input_tensors[0];
+        auto output_tensor = output_tensors[0];
+
+        // Basic validation of tensor ranks
+        auto input_shape = input_tensor->getShape();
+        auto output_shape = output_tensor->getShape();
+
+        // Only float types supported for now
+        if (input_tensor->getDType() != DType::FLOAT32) {
+            std::cerr << "Matrix transform currently only supports FLOAT32 tensors" << std::endl;
+            return 1;
+        }
+
+        // For each transform type, delegate to the appropriate function
+        if (transform_type == "transpose") {
+            return evaluateTranspose(input_tensor, output_tensor, attrs);
+        } else if (transform_type == "reshape") {
+            return evaluateReshape(input_tensor, output_tensor, attrs);
+        } else if (transform_type == "pack") {
+            return evaluatePack(input_tensor, output_tensor, attrs);
+        } else {
+            std::cerr << "Unknown transform type: " << transform_type << std::endl;
+            return 1;
+        }
+    }
+
+    std::string getDomainName() const override
+    {
+        return this->_domain_name;
+    }
+
+    std::string getOperatorName() const override
+    {
+        return this->_operator_name;
+    }
+
+    std::string getVersion() const override
+    {
+        return this->_version;
+    }
+
+    ~MatrixTransformOp(){}
+
+private:
+    int evaluateTranspose(TosaReference::Tensor* input_tensor, 
+                          TosaReference::Tensor* output_tensor,
+                          const json& attrs)
+    {
+        using TIn = Eigen::Tensor<float, 4>;
+        using TOut = Eigen::Tensor<float, 4>;
+
+        // Get permutation from attributes or use default
+        std::vector<int32_t> perm;
+        if (attrs.contains("perm")) {
+            perm = attrs["perm"].get<std::vector<int32_t>>();
+        } else {
+            // Default permutation for matrix transpose
+            auto rank = input_tensor->getRank();
+            perm.resize(rank);
+            for (int i = 0; i < rank; i++) {
+                perm[i] = i;
+            }
+            // Swap last two dimensions for standard matrix transpose
+            if (rank >= 2) {
+                std::swap(perm[rank-1], perm[rank-2]);
+            }
+        }
+
+        // Get the rank of the input tensor
+        auto rank = input_tensor->getRank();
+
+        // Validate permutation
+        if (perm.size() != rank) {
+            std::cerr << "Permutation size does not match tensor rank" << std::endl;
+            return 1;
+        }
+
+        // Handle based on tensor rank
+        switch (rank) {
+            case 1: {
+                auto eigenInputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 1>>*>(input_tensor);
+                auto eigenOutputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 1>>*>(output_tensor);
+                // For rank 1, transpose is a no-op
+                eigenOutputTensor->getTensor() = eigenInputTensor->getTensor();
+                break;
+            }
+            case 2: {
+                auto eigenInputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 2>>*>(input_tensor);
+                auto eigenOutputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 2>>*>(output_tensor);
+                // Use Eigen's shuffle to implement the permutation
+                Eigen::array<int, 2> shuffleArray = {perm[0], perm[1]};
+                eigenOutputTensor->getTensor() = eigenInputTensor->getTensor().shuffle(shuffleArray);
+                break;
+            }
+            case 3: {
+                auto eigenInputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 3>>*>(input_tensor);
+                auto eigenOutputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 3>>*>(output_tensor);
+                // Use Eigen's shuffle to implement the permutation
+                Eigen::array<int, 3> shuffleArray = {perm[0], perm[1], perm[2]};
+                eigenOutputTensor->getTensor() = eigenInputTensor->getTensor().shuffle(shuffleArray);
+                break;
+            }
+            case 4: {
+                auto eigenInputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 4>>*>(input_tensor);
+                auto eigenOutputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 4>>*>(output_tensor);
+                // Use Eigen's shuffle to implement the permutation
+                Eigen::array<int, 4> shuffleArray = {perm[0], perm[1], perm[2], perm[3]};
+                eigenOutputTensor->getTensor() = eigenInputTensor->getTensor().shuffle(shuffleArray);
+                break;
+            }
+            default:
+                std::cerr << "Transpose only supports tensors with rank <= 4" << std::endl;
+                return 1;
+        }
+
+        return 0;
+    }
+
+    int evaluateReshape(TosaReference::Tensor* input_tensor, 
+                         TosaReference::Tensor* output_tensor,
+                         const json& attrs)
+    {
+        // Check if shapes are compatible (same total number of elements)
+        auto input_shape = input_tensor->getShape();
+        auto output_shape = output_tensor->getShape();
+
+        int64_t input_size = 1;
+        for (auto dim : input_shape) {
+            input_size *= dim;
+        }
+
+        int64_t output_size = 1;
+        for (auto dim : output_shape) {
+            output_size *= dim;
+        }
+
+        if (input_size != output_size) {
+            std::cerr << "Reshape requires input and output tensors to have the same number of elements" << std::endl;
+            return 1;
+        }
+
+        // Reshape is essentially a memory copy operation with same elements but different layout
+        // Get input data as flat array of float values
+        auto eigenInputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 1>>*>(input_tensor);
+        auto eigenOutputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 1>>*>(output_tensor);
+
+        // Create a flat view of the input tensor
+        Eigen::Tensor<float, 1> inputFlat = Eigen::TensorMap<Eigen::Tensor<float, 1>>(
+            eigenInputTensor->getTensor().data(), input_size);
+
+        // Create a flat view of the output tensor
+        Eigen::Tensor<float, 1> outputFlat = Eigen::TensorMap<Eigen::Tensor<float, 1>>(
+            eigenOutputTensor->getTensor().data(), output_size);
+
+        // Copy data from input to output
+        outputFlat = inputFlat;
+
+        return 0;
+    }
+
+    int evaluatePack(TosaReference::Tensor* input_tensor, 
+                      TosaReference::Tensor* output_tensor,
+                      const json& attrs)
+    {
+        // Matrix packing operation for efficient computation
+        // Typically used for packing matrices for GEMM operations
+
+        // Get packing type from attributes
+        std::string pack_type = attrs.value("pack_type", "column_major");
+        int block_size = attrs.value("block_size", 8); // Default block size
+
+        auto input_shape = input_tensor->getShape();
+        auto output_shape = output_tensor->getShape();
+
+        // Ensure input is a matrix (rank 2)
+        if (input_shape.size() != 2) {
+            std::cerr << "Matrix packing requires a rank-2 input tensor" << std::endl;
+            return 1;
+        }
+
+        // Get dimensions
+        int rows = input_shape[0];
+        int cols = input_shape[1];
+
+        // Convert tensors to appropriate Eigen types
+        auto eigenInputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 2>>*>(input_tensor);
+        auto eigenOutputTensor = reinterpret_cast<TosaReference::TensorTemplate<Eigen::Tensor<float, 2>>*>(output_tensor);
+        
+        // Get references to Eigen tensors
+        auto& inputTensor = eigenInputTensor->getTensor();
+        auto& outputTensor = eigenOutputTensor->getTensor();
+
+        // Perform packing based on type
+        if (pack_type == "column_major") {
+            // Simple column-major packing (essentially a transpose)
+            Eigen::array<int, 2> shuffleArray = {1, 0}; // Transpose dimensions
+            outputTensor = inputTensor.shuffle(shuffleArray);
+        } 
+        else if (pack_type == "block") {
+            // Block-based packing for efficient matrix multiplication
+            // This is a simplified implementation - real implementations would be more complex
+            
+            // Calculate number of block rows and columns
+            int block_rows = (rows + block_size - 1) / block_size;
+            int block_cols = (cols + block_size - 1) / block_size;
+            
+            // Ensure output shape is correct for blocked format
+            if (output_shape[0] != block_rows * block_cols && 
+                output_shape[1] != block_size * block_size) {
+                std::cerr << "Output shape not compatible with block packing" << std::endl;
+                return 1;
+            }
+            
+            // Initialize output to zeros
+            outputTensor.setZero();
+            
+            // Pack input into blocks
+            for (int i = 0; i < block_rows; i++) {
+                for (int j = 0; j < block_cols; j++) {
+                    int block_idx = i * block_cols + j;
+                    
+                    // Copy data from input block to output block
+                    for (int bi = 0; bi < block_size; bi++) {
+                        for (int bj = 0; bj < block_size; bj++) {
+                            int row = i * block_size + bi;
+                            int col = j * block_size + bj;
+                            
+                            // Check bounds
+                            if (row < rows && col < cols) {
+                                // Linear index in output
+                                int out_idx = block_idx * block_size * block_size + bi * block_size + bj;
+                                
+                                // Set output element
+                                outputTensor(out_idx / (block_size * block_size), 
+                                             out_idx % (block_size * block_size)) = 
+                                    inputTensor(row, col);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            std::cerr << "Unknown packing type: " << pack_type << std::endl;
+            return 1;
+        }
+
+        return 0;
+    }
+
+    std::string _domain_name;
+    std::string _operator_name;
+    std::string _version;
+};
+
+CustomOpInterface* createMatrixTransformOp()
+{
+    std::string domain_name = "TosaMlirCustom";
+    std::string operator_name = "MatrixTransform";
+    std::string version = "1.0";
+    CustomOpInterface* customOp_ptr = new MatrixTransformOp(domain_name, operator_name, version);
+
+    return customOp_ptr;
+}
+
+extern "C" TOSA_EXPORT int getCustomOpCreationFuncs(registration_callback_t registration_func)
+{
+    std::string domain_name = "TosaMlirCustom";
+    std::string operator_name = "MatrixTransform";
+    return registration_func(domain_name, operator_name, &createMatrixTransformOp);
+}
+
+} // namespace TosaReference

--- a/verif/tosa_tests/custom/attention/desc.json
+++ b/verif/tosa_tests/custom/attention/desc.json
@@ -1,0 +1,23 @@
+{
+  "tosa_file": "test.tosa",
+  "ifm_name": ["query", "key", "value"],
+  "ifm_file": ["query.npy", "key.npy", "value.npy"],
+  "ofm_name": ["output"],
+  "ofm_file": ["output.npy"],
+  "description": "Attention operation test - scaled dot product",
+  "precision": {
+    "operator": "Attention",
+    "data_type": "FLOAT32",
+    "compliance": {
+      "mode": "ULP",
+      "ulp_tolerance": 4
+    }
+  },
+  "expected_failure": false,
+  "expected_failure_desc": "",
+  "meta": {
+    "custom_domain": "TosaMlirCustom",
+    "custom_op": "Attention",
+    "implementation_attrs": "{\"attention_type\":\"scaled_dot_product\", \"scale\": 0.125}"
+  }
+}

--- a/verif/tosa_tests/custom/matrix_transform/desc.json
+++ b/verif/tosa_tests/custom/matrix_transform/desc.json
@@ -1,0 +1,22 @@
+{
+  "tosa_file": "test.tosa",
+  "ifm_name": ["input"],
+  "ifm_file": ["input.npy"],
+  "ofm_name": ["output"],
+  "ofm_file": ["output.npy"],
+  "description": "Matrix transform operation test - transpose",
+  "precision": {
+    "operator": "MatrixTransform",
+    "data_type": "FLOAT32",
+    "compliance": {
+      "mode": "EXACT"
+    }
+  },
+  "expected_failure": false,
+  "expected_failure_desc": "",
+  "meta": {
+    "custom_domain": "TosaMlirCustom",
+    "custom_op": "MatrixTransform",
+    "implementation_attrs": "{\"transform_type\":\"transpose\"}"
+  }
+}


### PR DESCRIPTION
This pull request introduces support for custom TOSA operations in the reference model, including the addition of a new Attention operation. The changes involve updates to the build system, the creation of a new plugin library for custom operations, and the implementation of the Attention operation with detailed validation and computation logic.

### Build System Updates:
* [`reference_model/CMakeLists.txt`](diffhunk://#diff-685e27324c9900a30b4a63cd6d69ac00a8dd12261c1dc7d9fe4c6c75dd0efe48R27-R29): Added a new subdirectory for custom TOSA operations, enabling the integration of custom plugins into the build process.

### Plugin Library for Custom Operations:
* [`reference_model/custom_tosa_ops/CMakeLists.txt`](diffhunk://#diff-67e35901aa16d8d55a4b3aa820b06fc0dc8d6620285f5146d7a1564c5bf8f05fR1-R45): Created a new CMake configuration for building the `tosa_custom_ops_plugin` shared library, specifying dependencies, include directories, and linking libraries like `eigen` and `flatbuffers`.

### Implementation of Attention Operation:
* [`reference_model/custom_tosa_ops/attention_op.cpp`](diffhunk://#diff-4e0d9bdfce6c8bd383cdc0dfef7649abe6a8b0c7ec06f9d359cf0f9fdb368f60R1-R325): Implemented the `AttentionOp` class, which supports scaled dot-product attention and validates input tensor shapes, types, and dimensions. The operation includes detailed logic for attention score computation, scaling, masking, softmax application, and weighted sum calculation.